### PR TITLE
feat(core): pin @google/clasp version to 3.1.0 in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,10 @@
     {
       "matchPackageNames": ["eslint-plugin-unused-imports"],
       "allowedVersions": "<4.0.0"
+    },
+    {
+      "matchPackageNames": ["@google/clasp"],
+      "allowedVersions": "3.1.0"
     }
   ]
 }


### PR DESCRIPTION
:magic_wand: :sparkles:

## Changes
- Add renovate rule to pin @google/clasp at version 3.1.0
- This prevents automatic upgrades that break clasp deployment

## Reference
Follows the pattern from gaccount-control-gas repository:
https://github.com/HiromiShikata/gaccount-control-gas/commit/a416467a91d48a4692a4c60bed367d4b5f7b4684

Closes #193