### PR TITLE
fix(ci): update GitHub Actions workflows for compatibility

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Set branch name as output
         id: branch_name
-        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         id: create_pr
@@ -27,7 +27,7 @@ jobs:
           pr_body: |
             :magic_wand: :sparkles:
 
-          draft: false
+          pr_draft: false
 
       - name: Assign PR to author
         if: steps.create_pr.outputs.pr_number
@@ -44,7 +44,7 @@ jobs:
         run: |
           PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pr_number }}")
           PR_ID=$(echo "$PR_DATA" | jq -r '.node_id')
-          echo "::set-output name=node_id::$PR_ID"
+          echo "node_id=$PR_ID" >> "$GITHUB_OUTPUT"
 
       - name: Enable Auto Merge for PR
         if: steps.create_pr.outputs.pr_number

--- a/.github/workflows/empty-format-test-job.yml
+++ b/.github/workflows/empty-format-test-job.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
:magic_wand: :sparkles:

## Changes
- Fix format workflow to use fallback token for dependabot PRs
- Update deprecated set-output commands to GITHUB_OUTPUT  
- Change draft parameter to pr_draft in create-pr workflow

closes #225