### PR TITLE
chore(core): change category:* label to llm-agent:* on all repos under HiromiShikata/* because category:* is deprecated

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -78,33 +78,39 @@
   aliases: []
   description: ''
   delete: false
-- name: category:impl-plan
+- name: llm-agent:impl-plan
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:impl-plan
   description: ''
   delete: false
-- name: category:review
+- name: llm-agent:review
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:review
   description: ''
   delete: false
-- name: category:accounting
+- name: llm-agent:accounting
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:accounting
   description: ''
   delete: false
-- name: category:deep-research
+- name: llm-agent:deep-research
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:deep-research
   description: ''
   delete: false
-- name: category:chore
+- name: llm-agent:chore
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:chore
   description: ''
   delete: false
-- name: category:browser
+- name: llm-agent:browser
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - category:browser
   description: ''
   delete: false


### PR DESCRIPTION
## Summary

Replace all \`category:*\` GitHub labels with \`llm-agent:*\` labels across all HiromiShikata repositories by updating \`labels.yaml\` to use \`github-label-sync\` aliases for seamless migration of existing labeled issues.

- close #253

Related: https://github.com/HiromiShikata/umino-corporait-operation/issues/27246