### PR TITLE
fix(core): skip create-pr workflow for dependabot and renovate bot pushes

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   create_and_enable_automerge:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
:magic_wand: :sparkles:\n\n- close #265