### PR TITLE
fix(core): api-created_issue_pr.yml uses removed GraphQL mutation addProjectNextItem

### DIFF
--- a/.github/workflows/api-created_issue_pr.yml
+++ b/.github/workflows/api-created_issue_pr.yml
@@ -4,9 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       issue_or_pr_url:
-        description: 'Issue or PR URL'
+        description: 'Issue or PR URL (https://github.com/<owner>/<repo>/issues/<number> or .../pull/<number>)'
         required: true
         default: ''
+
+env:
+  PROJECT_V2_ID: PVT_kwHOAGJHa84AFWnr
 
 jobs:
   add-to-project:
@@ -14,22 +17,20 @@ jobs:
     steps:
       - name: Add to Project
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           ISSUE_OR_PR_URL="${{ github.event.inputs.issue_or_pr_url }}"
+          ISSUE_OR_PR_URL="${ISSUE_OR_PR_URL%%\?*}"
+          ISSUE_OR_PR_URL="${ISSUE_OR_PR_URL%/}"
+
+          if ! echo "$ISSUE_OR_PR_URL" | grep -qE '^https://github\.com/[^/]+/[^/]+/(issues|pull)/[0-9]+$'; then
+            echo "Invalid URL format. Expected: https://github.com/<owner>/<repo>/issues/<number> or .../pull/<number>"
+            echo "Got: $ISSUE_OR_PR_URL"
+            exit 1
+          fi
 
           REPO_PATH=$(echo "$ISSUE_OR_PR_URL" | awk -F'/' '{print $4"/"$5}')
           NUMBER=$(echo "$ISSUE_OR_PR_URL" | grep -oE '[0-9]+$')
-
-          if [ -z "$NUMBER" ]; then
-            echo "Failed to extract number from URL: $ISSUE_OR_PR_URL"
-            exit 1
-          fi
-
-          if [ -z "$REPO_PATH" ]; then
-            echo "Failed to extract repo path from URL: $ISSUE_OR_PR_URL"
-            exit 1
-          fi
 
           if echo "$ISSUE_OR_PR_URL" | grep -q "/pull/"; then
             RESOURCE_TYPE="pulls"
@@ -37,21 +38,37 @@ jobs:
             RESOURCE_TYPE="issues"
           fi
 
-          REST_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$REPO_PATH/$RESOURCE_TYPE/$NUMBER")
-          NODE_ID=$(echo "$REST_RESPONSE" | jq -r '.node_id')
+          REST_RESPONSE=$(curl -s -w "\n%{http_code}" -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/$REPO_PATH/$RESOURCE_TYPE/$NUMBER")
+          HTTP_STATUS=$(echo "$REST_RESPONSE" | tail -n1)
+          REST_BODY=$(echo "$REST_RESPONSE" | sed '$d')
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "REST API returned HTTP $HTTP_STATUS"
+            echo "$REST_BODY"
+            exit 1
+          fi
+
+          NODE_ID=$(echo "$REST_BODY" | jq -r '.node_id')
 
           if [ -z "$NODE_ID" ] || [ "$NODE_ID" = "null" ]; then
             echo "Failed to get node ID. REST response:"
-            echo "$REST_RESPONSE"
+            echo "$REST_BODY"
             exit 1
           fi
 
           echo "Node ID: $NODE_ID"
 
-          RESPONSE=$(curl -s -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
-                             -H "Content-Type: application/json" \
-                             https://api.github.com/graphql \
-                             -d "{\"query\":\"mutation { addProjectV2ItemById(input: { contentId: \\\"$NODE_ID\\\", projectId: \\\"PVT_kwHOAGJHa84AFWnr\\\" }) { item { id } } }\"}")
+          GRAPHQL_PAYLOAD=$(jq -n \
+            --arg nodeId "$NODE_ID" \
+            --arg projectId "$PROJECT_V2_ID" \
+            '{"query": "mutation($contentId: ID!, $projectId: ID!) { addProjectV2ItemById(input: { contentId: $contentId, projectId: $projectId }) { item { id } } }", "variables": {"contentId": $nodeId, "projectId": $projectId}}')
+
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: bearer $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/graphql \
+            -d "$GRAPHQL_PAYLOAD")
           echo "$RESPONSE"
 
           if ! echo "$RESPONSE" | jq '.' > /dev/null 2>&1; then

--- a/.github/workflows/api-created_issue_pr.yml
+++ b/.github/workflows/api-created_issue_pr.yml
@@ -1,0 +1,65 @@
+name: Add to Project
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_or_pr_url:
+        description: 'Issue or PR URL'
+        required: true
+        default: ''
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to Project
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ISSUE_OR_PR_URL="${{ github.event.inputs.issue_or_pr_url }}"
+
+          REPO_PATH=$(echo "$ISSUE_OR_PR_URL" | awk -F'/' '{print $4"/"$5}')
+          NUMBER=$(echo "$ISSUE_OR_PR_URL" | grep -oE '[0-9]+$')
+
+          if [ -z "$NUMBER" ]; then
+            echo "Failed to extract number from URL: $ISSUE_OR_PR_URL"
+            exit 1
+          fi
+
+          if [ -z "$REPO_PATH" ]; then
+            echo "Failed to extract repo path from URL: $ISSUE_OR_PR_URL"
+            exit 1
+          fi
+
+          if echo "$ISSUE_OR_PR_URL" | grep -q "/pull/"; then
+            RESOURCE_TYPE="pulls"
+          else
+            RESOURCE_TYPE="issues"
+          fi
+
+          REST_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$REPO_PATH/$RESOURCE_TYPE/$NUMBER")
+          NODE_ID=$(echo "$REST_RESPONSE" | jq -r '.node_id')
+
+          if [ -z "$NODE_ID" ] || [ "$NODE_ID" = "null" ]; then
+            echo "Failed to get node ID. REST response:"
+            echo "$REST_RESPONSE"
+            exit 1
+          fi
+
+          echo "Node ID: $NODE_ID"
+
+          RESPONSE=$(curl -s -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
+                             -H "Content-Type: application/json" \
+                             https://api.github.com/graphql \
+                             -d "{\"query\":\"mutation { addProjectV2ItemById(input: { contentId: \\\"$NODE_ID\\\", projectId: \\\"PVT_kwHOAGJHa84AFWnr\\\" }) { item { id } } }\"}")
+          echo "$RESPONSE"
+
+          if ! echo "$RESPONSE" | jq '.' > /dev/null 2>&1; then
+            echo "Non-JSON response received"
+            exit 1
+          fi
+
+          if echo "$RESPONSE" | jq -e '.errors' > /dev/null; then
+            echo "GraphQL error occurred"
+            exit 1
+          fi

--- a/.github/workflows/repositories-management.yml
+++ b/.github/workflows/repositories-management.yml
@@ -42,6 +42,7 @@ jobs:
             ".github/workflows/commit-lint.yml"
             ".github/workflows/configs/commitlint.config.js"
             ".github/workflows/create-pr.yml"
+            ".github/workflows/api-created_issue_pr.yml"
             ".github/CODEOWNERS"
             ".github/copilot-instructions.md"
             ".github/instructions/code-review.instructions.md"


### PR DESCRIPTION
## Summary

- Replace removed `addProjectNextItem` GraphQL mutation with `addProjectV2ItemById`
- Fetch node_id via REST API (addProjectV2ItemById requires global node ID, not numeric ID)
- Remove deprecated `::set-output` syntax by using awk-based URL parsing (avoids sed delimiter conflict with `|` in patterns)
- Add JSON validity check for GraphQL response
- Add `.github/workflows/api-created_issue_pr.yml` to FILES_TO_SYNC so the fix is deployed to all repos

- close #276
- close HiromiShikata/personal-task#10422