### PR TITLE
test(core): add SlashCommand entity with regression tests for slash command detection

### DIFF
--- a/scripts/typescript/package.json
+++ b/scripts/typescript/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prebuild": "npm run doctor",
-    "doctor:node-version": "check-node-version --node 20 --npx 10 --npm 10",
+    "doctor:node-version": "check-node-version --node 24 --npx 10 --npm 10",
     "doctor": "npm run doctor:node-version",
     "prettier": "prettier --write '**/*'",
     "lint": "eslint src",
@@ -42,7 +42,7 @@
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^29.5.13",
-    "@types/node": "^22.0.0",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "check-node-version": "^4.2.1",

--- a/scripts/typescript/package.json
+++ b/scripts/typescript/package.json
@@ -42,6 +42,7 @@
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
     "@types/jest": "^29.5.13",
+    "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "check-node-version": "^4.2.1",

--- a/scripts/typescript/src/domain/entities/SlashCommand.test.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.test.ts
@@ -1,0 +1,170 @@
+import { SlashCommand } from './SlashCommand';
+
+describe('SlashCommand', () => {
+  describe('detectCreateIssue', () => {
+    test('detects command at start of comment', () => {
+      const result = SlashCommand.detectCreateIssue('/createissue Fix the bug');
+      expect(result).not.toBeNull();
+      expect(result?.title).toBe('Fix the bug');
+    });
+
+    test('detects command after newline', () => {
+      const result = SlashCommand.detectCreateIssue(
+        'Some text\n/createissue Fix the bug',
+      );
+      expect(result).not.toBeNull();
+      expect(result?.title).toBe('Fix the bug');
+    });
+
+    test('detects command with leading whitespace on line', () => {
+      const result = SlashCommand.detectCreateIssue(
+        'Some text\n  /createissue Fix the bug',
+      );
+      expect(result).not.toBeNull();
+      expect(result?.title).toBe('Fix the bug');
+    });
+
+    test('does not fire when /createissue appears mid-line', () => {
+      const result = SlashCommand.detectCreateIssue(
+        'the /createissue step used a plain substring match',
+      );
+      expect(result).toBeNull();
+    });
+
+    test('does not fire on completion report from issue #274 scenario', () => {
+      const completionReport = `From: :robot: HS Implement AI Agent
+
+## Root cause of problem and why this changes work
+
+This issue was unintentionally created because the /createissue step used a plain substring match (contains()), so a mention of \`/createissue\` anywhere in a comment body triggered issue creation.
+
+The fix applies two layers:
+1. The step-level if: condition keeps contains() as a coarse prefilter
+2. Each script now adds a strict line-anchored regex check at the top
+
+## CI status
+All CI checks passed.`;
+      expect(SlashCommand.detectCreateIssue(completionReport)).toBeNull();
+    });
+
+    test('does not fire on backtick-formatted /createissue reference', () => {
+      const result = SlashCommand.detectCreateIssue(
+        'Use `` `/createissue` `` to create an issue',
+      );
+      expect(result).toBeNull();
+    });
+
+    test('does not fire on URL containing /createissue', () => {
+      const result = SlashCommand.detectCreateIssue(
+        'See https://example.com/createissue for details',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('detectClose', () => {
+    test('detects /close at start of comment', () => {
+      expect(SlashCommand.detectClose('/close')).toBe(true);
+    });
+
+    test('detects /done at start of comment', () => {
+      expect(SlashCommand.detectClose('/done')).toBe(true);
+    });
+
+    test('detects /close after newline', () => {
+      expect(SlashCommand.detectClose('Some text\n/close')).toBe(true);
+    });
+
+    test('does not fire on rejected/closed substring', () => {
+      expect(
+        SlashCommand.detectClose(
+          'PR #427 was rejected/closed due to failing tests',
+        ),
+      ).toBe(false);
+    });
+
+    test('does not fire on /closed', () => {
+      expect(SlashCommand.detectClose('The ticket is /closed')).toBe(false);
+    });
+
+    test('does not fire on /closing', () => {
+      expect(SlashCommand.detectClose('We are /closing the issue')).toBe(false);
+    });
+
+    test('does not fire on /donerequest', () => {
+      expect(SlashCommand.detectClose('/donerequest submitted')).toBe(false);
+    });
+
+    test('does not fire on URL path ending in /close', () => {
+      expect(
+        SlashCommand.detectClose('Visit https://example.com/close to close'),
+      ).toBe(false);
+    });
+
+    test('does not fire on /done in middle of line', () => {
+      expect(SlashCommand.detectClose('if (foo) { /done */ } else {}')).toBe(
+        false,
+      );
+    });
+
+    test('detects /close with reason on same line', () => {
+      expect(SlashCommand.detectClose('/close resolved by PR #123')).toBe(true);
+    });
+  });
+
+  describe('detectMoveNextActionDate', () => {
+    test('detects command at start of comment', () => {
+      expect(
+        SlashCommand.detectMoveNextActionDate('/movenextactiondateto 20260601'),
+      ).toBe('20260601');
+    });
+
+    test('detects command after newline', () => {
+      expect(
+        SlashCommand.detectMoveNextActionDate(
+          'Some text\n/movenextactiondateto 20260601',
+        ),
+      ).toBe('20260601');
+    });
+
+    test('does not fire when command appears mid-line', () => {
+      expect(
+        SlashCommand.detectMoveNextActionDate(
+          'Use /movenextactiondateto to update the date',
+        ),
+      ).toBeNull();
+    });
+
+    test('returns null when no date provided', () => {
+      expect(
+        SlashCommand.detectMoveNextActionDate('/movenextactiondateto'),
+      ).toBeNull();
+    });
+  });
+
+  describe('detectChangeAssignee', () => {
+    test('detects command at start of comment', () => {
+      expect(SlashCommand.detectChangeAssignee('/changeassignee octocat')).toBe(
+        'octocat',
+      );
+    });
+
+    test('detects command after newline', () => {
+      expect(
+        SlashCommand.detectChangeAssignee('Some text\n/changeassignee octocat'),
+      ).toBe('octocat');
+    });
+
+    test('does not fire when command appears mid-line', () => {
+      expect(
+        SlashCommand.detectChangeAssignee(
+          'Use /changeassignee username to reassign',
+        ),
+      ).toBeNull();
+    });
+
+    test('does not fire without username argument', () => {
+      expect(SlashCommand.detectChangeAssignee('/changeassignee')).toBeNull();
+    });
+  });
+});

--- a/scripts/typescript/src/domain/entities/SlashCommand.test.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.test.ts
@@ -178,6 +178,14 @@ All CI checks passed.`;
         SlashCommand.detectMoveNextActionDate('/movenextactiondateto'),
       ).toBeNull();
     });
+
+    test('returns null when command line lacks date but later mid-line reference has one', () => {
+      expect(
+        SlashCommand.detectMoveNextActionDate(
+          '/movenextactiondateto\nsome text /movenextactiondateto 20260601',
+        ),
+      ).toBeNull();
+    });
   });
 
   describe('detectChangeAssignee', () => {

--- a/scripts/typescript/src/domain/entities/SlashCommand.test.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.test.ts
@@ -1,19 +1,57 @@
-import { SlashCommand } from './SlashCommand';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SlashCommand, SLASH_COMMAND_PATTERNS } from './SlashCommand';
 
 describe('SlashCommand', () => {
+  describe('workflow regex parity', () => {
+    const workflowContent = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../../../../.github/workflows/umino-project.yml',
+      ),
+      'utf8',
+    );
+
+    test('umino-project.yml uses the same createissue pattern', () => {
+      expect(workflowContent).toContain(
+        SLASH_COMMAND_PATTERNS.createissue.source,
+      );
+    });
+
+    test('umino-project.yml uses the same closeOrDone pattern', () => {
+      expect(workflowContent).toContain(
+        SLASH_COMMAND_PATTERNS.closeOrDone.source,
+      );
+    });
+
+    test('umino-project.yml uses the same movenextactiondateto pattern', () => {
+      expect(workflowContent).toContain(
+        SLASH_COMMAND_PATTERNS.movenextactiondateto.source,
+      );
+    });
+
+    test('umino-project.yml uses the same changeassignee pattern', () => {
+      expect(workflowContent).toContain(
+        SLASH_COMMAND_PATTERNS.changeassignee.source,
+      );
+    });
+  });
+
   describe('detectCreateIssue', () => {
     test('detects command at start of comment', () => {
       const result = SlashCommand.detectCreateIssue('/createissue Fix the bug');
       expect(result).not.toBeNull();
       expect(result?.title).toBe('Fix the bug');
+      expect(result?.body).toBe('Fix the bug');
     });
 
-    test('detects command after newline', () => {
+    test('detects command after newline with multi-line body', () => {
       const result = SlashCommand.detectCreateIssue(
-        'Some text\n/createissue Fix the bug',
+        'Some text\n/createissue Fix the bug\nBody line 2',
       );
       expect(result).not.toBeNull();
       expect(result?.title).toBe('Fix the bug');
+      expect(result?.body).toBe('Fix the bug\nBody line 2');
     });
 
     test('detects command with leading whitespace on line', () => {

--- a/scripts/typescript/src/domain/entities/SlashCommand.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.ts
@@ -1,0 +1,50 @@
+export type SlashCommandType =
+  | 'createissue'
+  | 'close'
+  | 'done'
+  | 'movenextactiondateto'
+  | 'changeassignee';
+
+export class SlashCommand {
+  constructor(
+    public readonly type: SlashCommandType,
+    public readonly argument: string,
+  ) {}
+
+  static detectCreateIssue(commentBody: string): {
+    title: string;
+    body: string;
+  } | null {
+    const commandMatch = /(^|\n)\s*\/createissue\b/m.exec(commentBody);
+    if (!commandMatch) return null;
+    const createIssueIndex = commentBody.indexOf(
+      '/createissue',
+      commandMatch.index,
+    );
+    const title = commentBody
+      .slice(createIssueIndex + 12)
+      .split('\n')[0]
+      .trim();
+    const body = commentBody.slice(createIssueIndex + 12).trim();
+    return { title, body };
+  }
+
+  static detectClose(commentBody: string): boolean {
+    return /(^|\n)\s*\/(close|done)\b/m.test(commentBody);
+  }
+
+  static detectMoveNextActionDate(commentBody: string): string | null {
+    const commandMatch = /(^|\n)\s*\/movenextactiondateto\b/m.exec(commentBody);
+    if (!commandMatch) return null;
+    const dateMatch = /\/movenextactiondateto\s+(\d{8})/.exec(
+      commentBody.slice(commandMatch.index),
+    );
+    return dateMatch ? dateMatch[1] : null;
+  }
+
+  static detectChangeAssignee(commentBody: string): string | null {
+    const commandMatch = /(^|\n)\s*\/changeassignee\s+(\S+)/m.exec(commentBody);
+    if (!commandMatch) return null;
+    return commandMatch[2].trim();
+  }
+}

--- a/scripts/typescript/src/domain/entities/SlashCommand.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.ts
@@ -5,6 +5,8 @@ export const SLASH_COMMAND_PATTERNS = {
   changeassignee: /(^|\n)\s*\/changeassignee\s+(\S+)/m,
 } as const;
 
+const CREATE_ISSUE_COMMAND = '/createissue';
+
 export class SlashCommand {
   static detectCreateIssue(commentBody: string): {
     title: string;
@@ -13,14 +15,15 @@ export class SlashCommand {
     const commandMatch = SLASH_COMMAND_PATTERNS.createissue.exec(commentBody);
     if (!commandMatch) return null;
     const createIssueIndex = commentBody.indexOf(
-      '/createissue',
+      CREATE_ISSUE_COMMAND,
       commandMatch.index,
     );
-    const title = commentBody
-      .slice(createIssueIndex + 12)
-      .split('\n')[0]
-      .trim();
-    const body = commentBody.slice(createIssueIndex + 12).trim();
+    const afterCommand = commentBody.slice(
+      createIssueIndex + CREATE_ISSUE_COMMAND.length,
+    );
+    const title = afterCommand.split('\n')[0].trim();
+    if (!title) return null;
+    const body = afterCommand.trim();
     return { title, body };
   }
 

--- a/scripts/typescript/src/domain/entities/SlashCommand.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.ts
@@ -1,21 +1,16 @@
-export type SlashCommandType =
-  | 'createissue'
-  | 'close'
-  | 'done'
-  | 'movenextactiondateto'
-  | 'changeassignee';
+export const SLASH_COMMAND_PATTERNS = {
+  createissue: /(^|\n)\s*\/createissue\b/m,
+  closeOrDone: /(^|\n)\s*\/(close|done)\b/m,
+  movenextactiondateto: /(^|\n)\s*\/movenextactiondateto\b/m,
+  changeassignee: /(^|\n)\s*\/changeassignee\s+(\S+)/m,
+} as const;
 
 export class SlashCommand {
-  constructor(
-    public readonly type: SlashCommandType,
-    public readonly argument: string,
-  ) {}
-
   static detectCreateIssue(commentBody: string): {
     title: string;
     body: string;
   } | null {
-    const commandMatch = /(^|\n)\s*\/createissue\b/m.exec(commentBody);
+    const commandMatch = SLASH_COMMAND_PATTERNS.createissue.exec(commentBody);
     if (!commandMatch) return null;
     const createIssueIndex = commentBody.indexOf(
       '/createissue',
@@ -30,11 +25,12 @@ export class SlashCommand {
   }
 
   static detectClose(commentBody: string): boolean {
-    return /(^|\n)\s*\/(close|done)\b/m.test(commentBody);
+    return SLASH_COMMAND_PATTERNS.closeOrDone.test(commentBody);
   }
 
   static detectMoveNextActionDate(commentBody: string): string | null {
-    const commandMatch = /(^|\n)\s*\/movenextactiondateto\b/m.exec(commentBody);
+    const commandMatch =
+      SLASH_COMMAND_PATTERNS.movenextactiondateto.exec(commentBody);
     if (!commandMatch) return null;
     const dateMatch = /\/movenextactiondateto\s+(\d{8})/.exec(
       commentBody.slice(commandMatch.index),
@@ -43,7 +39,8 @@ export class SlashCommand {
   }
 
   static detectChangeAssignee(commentBody: string): string | null {
-    const commandMatch = /(^|\n)\s*\/changeassignee\s+(\S+)/m.exec(commentBody);
+    const commandMatch =
+      SLASH_COMMAND_PATTERNS.changeassignee.exec(commentBody);
     if (!commandMatch) return null;
     return commandMatch[2].trim();
   }

--- a/scripts/typescript/src/domain/entities/SlashCommand.ts
+++ b/scripts/typescript/src/domain/entities/SlashCommand.ts
@@ -35,9 +35,11 @@ export class SlashCommand {
     const commandMatch =
       SLASH_COMMAND_PATTERNS.movenextactiondateto.exec(commentBody);
     if (!commandMatch) return null;
-    const dateMatch = /\/movenextactiondateto\s+(\d{8})/.exec(
-      commentBody.slice(commandMatch.index),
-    );
+    const commandLine = commentBody
+      .slice(commandMatch.index)
+      .replace(/^\n/, '')
+      .split('\n')[0];
+    const dateMatch = /\/movenextactiondateto\s+(\d{8})/.exec(commandLine);
     return dateMatch ? dateMatch[1] : null;
   }
 

--- a/scripts/typescript/tsconfig.json
+++ b/scripts/typescript/tsconfig.json
@@ -9,7 +9,9 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["jest", "node"],
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/*"]


### PR DESCRIPTION
Add SlashCommand domain entity with line-anchored regex detection methods matching the patterns used in umino-project.yml workflow. Tests cover the false positive scenarios that accidentally created issues #272 and #274 (e.g. /createissue mentioned mid-line in completion reports), ensuring the fix from PR #273 is verified and cannot silently regress.

Also fix tsconfig.json to explicitly declare jest and node types (required by TypeScript 6) and suppress the deprecated moduleResolution warning.

- close #274