### PR TITLE
fix(core): fix non-executable llm-model label values and add codex label

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -108,17 +108,25 @@
   aliases: []
   description: ''
   delete: false
-- name: llm-model:claude-opus-4.6
+- name: llm-model:claude-opus-4-6
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - llm-model:claude-opus-4.6
   description: ''
   delete: false
-- name: llm-model:claude-sonnet-4.6
+- name: llm-model:claude-sonnet-4-6
   color: '#0E8A16'
-  aliases: []
+  aliases:
+    - llm-model:claude-sonnet-4.6
   description: ''
   delete: false
-- name: llm-model:claude-haiku
+- name: llm-model:claude-haiku-4-5
+  color: '#0E8A16'
+  aliases:
+    - llm-model:claude-haiku
+  description: ''
+  delete: false
+- name: llm-model:gpt-5.5
   color: '#0E8A16'
   aliases: []
   description: ''


### PR DESCRIPTION
## Summary

- Rename `llm-model:claude-opus-4.6` to `llm-model:claude-opus-4-6` (old name kept as alias for automatic migration)
- Rename `llm-model:claude-sonnet-4.6` to `llm-model:claude-sonnet-4-6` (old name kept as alias for automatic migration)
- Rename `llm-model:claude-haiku` to `llm-model:claude-haiku-4-5` (old name kept as alias for automatic migration)
- Add `llm-model:gpt-5.5` (verified accepted by Codex CLI)

## Verification

All new model slugs verified via direct CLI invocation:

- claude-agent --model claude-opus-4-6 --max-budget-usd 0.01 → proceeds past model selection (stops at budget cap)
- claude-agent --model claude-sonnet-4-6 --max-budget-usd 0.01 → proceeds past model selection (stops at budget cap)
- claude-agent --model claude-haiku-4-5 --max-budget-usd 0.01 → proceeds past model selection (stops at budget cap)
- codex exec --model gpt-5.5 ... → accepted, returned 2

Note: gpt-5.2-codex was excluded because the CLI rejected it with 'not supported when using Codex with a ChatGPT account'.

- close #280