### PR TITLE
Fix: stop deleting the accounting routing label

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -126,7 +126,7 @@
   color: '#0E8A16'
   aliases: []
   description: ''
-  delete: true
+  delete: false
 - name: category:deep-research
   color: '#0E8A16'
   aliases: []


### PR DESCRIPTION
## Problem

In `labels.yaml`, the `accounting` label was placed inside the block of deprecated `category:*` labels and marked `delete: true`. The label-sync therefore deletes the `accounting` label on every run (daily cron and on push to main). Deleting a label removes it from every issue that carries it, so all issues labeled `accounting` silently lose the label after each sync.

`accounting` is an active routing label (it selects the accounting agent), so it must be kept like `chore` and `story`.

## Fix

Set `accounting` to `delete: false` (matching `chore` and `story`). No other entries changed.

## Impact

The label-sync will keep the `accounting` label instead of deleting it, so issues retain their accounting routing label across sync runs.