### PR TITLE
fix(ci): skip umino-project jobs for dependabot[bot] actor

### DIFF
--- a/.github/workflows/umino-project.yml
+++ b/.github/workflows/umino-project.yml
@@ -50,6 +50,7 @@ env:
 jobs:
   umino-job:
     if: >-
+      github.actor != 'dependabot[bot]' &&
       ((github.event_name != 'issue_comment') ||
        (github.event.comment.user.login == 'HiromiShikata' &&
         (contains(github.event.comment.body, '/createissue') ||
@@ -275,6 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues in pull requests
     if: >-
+      github.actor != 'dependabot[bot]' &&
       (github.event_name == 'pull_request')
     steps:
       - uses: step-security/harden-runner@v2


### PR DESCRIPTION
This is the source-file fix for HiromiShikata/npm-cli-github-issue-tower-defence-management/issues/900 in the repositories-management source repo.

Both `umino-job` and `check_pull_requests_to_link_issues` jobs in `.github/workflows/umino-project.yml` require the `HS_BOT_GH_AP_CLIENT_ID` secret to generate a GitHub App installation token. GitHub's security model does not provide repository secrets to workflows where `actor` is `dependabot[bot]`, causing both jobs to fail on every Dependabot PR.

The fix adds `github.actor != 'dependabot[bot]'` at the job level for both jobs, matching the same pattern already used in `create-pr.yml`. Dependabot PRs do not need UMINO Project board management or linked-issue enforcement, so skipping both jobs for the Dependabot actor is correct behavior.

The downstream fix for the primary issue is in https://github.com/HiromiShikata/npm-cli-github-issue-tower-defence-management/pull/902 — this PR fixes the source template so future syncs propagate the fix to all repos.