### PR TITLE
fix(repositories-management.yml): update sync to use commitlint.config.cjs

### DIFF
--- a/.github/workflows/repositories-management.yml
+++ b/.github/workflows/repositories-management.yml
@@ -53,7 +53,7 @@ jobs:
           FILES_TO_SYNC=(
             ".github/workflows/umino-project.yml"
             ".github/workflows/commit-lint.yml"
-            ".github/workflows/configs/commitlint.config.js"
+            ".github/workflows/configs/commitlint.config.cjs"
             ".github/workflows/create-pr.yml"
             ".github/workflows/api-created_issue_pr.yml"
             ".github/workflows/close-manual-prs.yml"


### PR DESCRIPTION
Closes https://github.com/HiromiShikata/repositories-management/issues/421

The sync script referenced `.github/workflows/configs/commitlint.config.js` but the file is named `.github/workflows/configs/commitlint.config.cjs`. This caused all sync runs to fail with:

```
cp: cannot stat '.github/workflows/configs/commitlint.config.js': No such file or directory
```

This fix corrects the filename in the `FILES_TO_SYNC` array.